### PR TITLE
Make REQUEST_TIME_THRESHOLD a setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-logutils
     :target: https://readthedocs.org/projects/django-logutils/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://coveralls.io/repos/jsmits/django-logutils/badge.svg?branch=master&service=github 
+.. image:: https://coveralls.io/repos/jsmits/django-logutils/badge.svg?branch=master&service=github
     :target: https://coveralls.io/github/jsmits/django-logutils?branch=master
 
 Various logging-related utilities for Django projects. For now, it provides
@@ -74,6 +74,10 @@ If settings.DEBUG is True or the request time is more than 1 second, two
 additional parameters are added to the logging dictionary: ``nr_queries`` that
 represents the number of queries executed during the request-response cycle
 and ``sql_time`` that represents the time it took to execute those queries.
+Slow requests are also raised to a loglevel of ``WARNING``.
+
+N.B.: the time threshold for slow requests can be overriden by using the
+``LOGUTILS_REQUEST_TIME_THRESHOLD`` setting in your project.
 
 EventLogger
 -----------

--- a/django_logutils/middleware.py
+++ b/django_logutils/middleware.py
@@ -101,8 +101,6 @@ class LoggingMiddleware(object):
         """
         Create the logging message..
         """
-        REQUEST_TIME_THRESHOLD = 1.
-
         try:
             log_dict = create_log_dict(request, response)
 
@@ -113,7 +111,8 @@ class LoggingMiddleware(object):
                 and self.start_time else -1)
             log_dict.update({'request_time': request_time})
 
-            is_request_time_too_high = request_time > REQUEST_TIME_THRESHOLD
+            is_request_time_too_high = (
+                request_time > float(appsettings.REQUEST_TIME_THRESHOLD))
             use_sql_info = settings.DEBUG or is_request_time_too_high
 
             log_msg = create_log_message(log_dict, use_sql_info)

--- a/django_logutils/models.py
+++ b/django_logutils/models.py
@@ -4,6 +4,7 @@ from appconf import AppConf
 
 class LogutilsAppConf(AppConf):
     LOGGING_MIDDLEWARE_EVENT = 'request'
+    REQUEST_TIME_THRESHOLD = 1.
 
     class Meta:
         prefix = 'logutils'


### PR DESCRIPTION
Implements #2 and updates the README accordingly. Allows `REQUEST_TIME_THRESHOLD` to be an int or float.
