### PR TITLE
Support StreamingHttpResponse that doesn't have content length

### DIFF
--- a/django_logutils/middleware.py
+++ b/django_logutils/middleware.py
@@ -27,6 +27,11 @@ def create_log_dict(request, response):
     if hasattr(request, 'user'):
         user_email = getattr(request.user, 'email', '-')
 
+    if response.streaming:
+        content_length = 'streaming'
+    else:
+        content_length = len(response.content)
+
     return {
         # 'event' makes event-based filtering possible in logging backends
         # like logstash
@@ -36,7 +41,7 @@ def create_log_dict(request, response):
         'method': request.method,
         'url': request.get_full_path(),
         'status': response.status_code,
-        'content_length': len(response.content),
+        'content_length': content_length,
         'request_time': -1,  # NA value: real value added by LoggingMiddleware
     }
 

--- a/tests/middleware/test_middleware.py
+++ b/tests/middleware/test_middleware.py
@@ -1,9 +1,12 @@
 import time
 
 from mock import Mock
+from mock import patch
 import pytest
 
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
+from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 
 from django_logutils import middleware
 
@@ -39,6 +42,17 @@ def test_empty_logging_middleware_response():
     lmw.process_request(request)
     response = lmw.process_response(request, response)
     assert response.status_code == 200
+
+
+@patch('django_logutils.middleware.logger')
+def test_streaming_http_response(mock_logger):
+    request = HttpRequest()
+    response = StreamingHttpResponse()
+    lmw = middleware.LoggingMiddleware()
+    lmw.process_request(request)
+    lmw.process_response(request, response)
+    assert (mock_logger.info.call_args[1]['extra']['content_length'] ==
+            'streaming')
 
 
 def test_logging_middleware_request_start_time():


### PR DESCRIPTION
When Django returns streaming content (like files), logging middleware throws an error that streaming content doesn't have a `content` attribute. This PR checks if response is streaming, if so, doesn't calculate length of response.
